### PR TITLE
RFC/RFT Cleanups to the wult drivers

### DIFF
--- a/drivers/idle/ndl/ndl.c
+++ b/drivers/idle/ndl/ndl.c
@@ -13,6 +13,7 @@
 #include <linux/netdevice.h>
 #include <linux/pci.h>
 #include <linux/string.h>
+#include <linux/types.h>
 
 #define DRIVER_NAME "ndl"
 #define NDL_VERSION "1.0"

--- a/drivers/idle/ndl/ndl.c
+++ b/drivers/idle/ndl/ndl.c
@@ -88,7 +88,7 @@ static struct pci_dev * __init find_pci_device(const struct net_device *ndev)
 		if (!pdev->driver || strcmp(pdev->driver->name, "igb"))
 			/* I210 devices are managed by the 'igb' driver. */
 			continue;
-		if (pdev->dev.driver_data == ndev)
+		if (pci_get_drvdata(pdev) == ndev)
 			break;
 	}
 

--- a/drivers/idle/ndl/ndl.c
+++ b/drivers/idle/ndl/ndl.c
@@ -118,7 +118,7 @@ static int ndl_do_init(void)
 	}
 
 	/* Get the base IO memory address. */
-	i210_iomem = pci_iomap(i210_pdev, 0, 0);
+	i210_iomem = pci_ioremap_bar(i210_pdev, 0);
 
 	err = dfs_create();
 	if (err)

--- a/drivers/idle/ndl/ndl.c
+++ b/drivers/idle/ndl/ndl.c
@@ -4,6 +4,8 @@
  * Author: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>
  */
 
+#define pr_fmt(fmt)	KBUILD_MODNAME ": " fmt
+
 #include <linux/debugfs.h>
 #include <linux/err.h>
 #include <linux/fs.h>
@@ -102,14 +104,13 @@ static int ndl_do_init(void)
 
 	i210_ndev = dev_get_by_name(&init_net, ifname);
 	if (!i210_ndev) {
-		pr_err(DRIVER_NAME ": network device '%s' was not found\n",
-		       ifname);
+		pr_err("network device '%s' was not found\n", ifname);
 		return -EINVAL;
 	}
 
 	i210_pdev = find_pci_device(i210_ndev);
 	if (!i210_pdev) {
-		pr_err(DRIVER_NAME ": cannot find PCI device for network device '%s'\n",
+		pr_err("cannot find PCI device for network device '%s'\n",
 		       i210_ndev->name);
 		err = -EINVAL;
 		goto error_put_ndev;
@@ -156,7 +157,7 @@ static int ndl_netdevice_event(struct notifier_block *notifier,
 	case NETDEV_REGISTER:
 		err = ndl_do_init();
 		if (err)
-			pr_err(DRIVER_NAME ": ndl init failed:%d\n", err);
+			pr_err("init failed:%d\n", err);
 		break;
 	case NETDEV_UNREGISTER:
 		ndl_do_exit();
@@ -178,7 +179,7 @@ static int __init ndl_init(void)
 	int err;
 
 	if (!ifname) {
-		pr_err(DRIVER_NAME ": network interface name not specified\n");
+		pr_err("network interface name not specified\n");
 		return -EINVAL;
 	}
 
@@ -188,7 +189,7 @@ static int __init ndl_init(void)
 
 	err = register_netdevice_notifier(&ndl_netdevice_notifier);
 	if (err) {
-		pr_err(DRIVER_NAME ": failed to register notifier\n");
+		pr_err("failed to register notifier\n");
 		ndl_do_exit();
 	}
 

--- a/drivers/idle/wult/cstates.c
+++ b/drivers/idle/wult/cstates.c
@@ -55,7 +55,7 @@ static struct cstate_info intel_cstates[] = {
 	{.name = "PC8", MSR_PKG_C8_RESIDENCY},
 	{.name = "PC9", MSR_PKG_C9_RESIDENCY},
 	{.name = "PC10", MSR_PKG_C10_RESIDENCY},
-	{NULL}
+	{}
 };
 
 /*
@@ -86,7 +86,7 @@ static int intel_cstate_init(struct wult_cstates_info *csinfo)
 }
 
 static struct cstate_info no_cstates[] = {
-	{NULL}
+	{}
 };
 
 /*

--- a/drivers/idle/wult/main.c
+++ b/drivers/idle/wult/main.c
@@ -430,8 +430,7 @@ static void __exit wult_exit(void)
 module_exit(wult_exit);
 
 module_param(cpunum, uint, 0444);
-MODULE_PARM_DESC(cpunum, "CPU number to measure wake latency on, default is "
-			 "CPU0.");
+MODULE_PARM_DESC(cpunum, "CPU number to measure wake latency on, default is CPU0.");
 
 MODULE_VERSION(WULT_VERSION);
 MODULE_DESCRIPTION("wake up latency measurement driver.");

--- a/drivers/idle/wult/main.c
+++ b/drivers/idle/wult/main.c
@@ -291,7 +291,7 @@ init_error:
 /* Initialize wult device information object 'wdi'. */
 static void init_wdi(struct wult_device_info *wdi)
 {
-	memset(wi, 0, sizeof(struct wult_info));
+	memset(wi, 0, sizeof(*wi));
 	wi->wdi = wdi;
 	wdi->priv = wi;
 	wi->cpunum = cpunum;
@@ -413,7 +413,7 @@ static int __init wult_init(void)
 		return -EINVAL;
 	}
 
-	wi = kzalloc(sizeof(struct wult_info), GFP_KERNEL);
+	wi = kzalloc(sizeof(*wi), GFP_KERNEL);
 
 	mutex_init(&wi->dev_mutex);
 	wi->cpunum = cpunum;

--- a/drivers/idle/wult/tracer.c
+++ b/drivers/idle/wult/tracer.c
@@ -354,7 +354,7 @@ static int wult_synth_event_init(struct wult_info *wi)
 
 	/* Add C-states fields. */
 	for_each_cstate(&ti->csinfo, csi) {
-		name_len = snprintf(name_buf, 64, "%sCyc", csi->name);
+		name_len = snprintf(name_buf, sizeof(name_buf), "%sCyc", csi->name);
 		if (name_len >= sizeof(name_buf)) {
 			err = -EINVAL;
 			goto out_free;

--- a/drivers/idle/wult/uapi.c
+++ b/drivers/idle/wult/uapi.c
@@ -139,68 +139,21 @@ static const struct file_operations dfs_ops_bool = {
 	.llseek = default_llseek,
 };
 
-static ssize_t dfs_read_rw_u64_file(struct file *file, char __user *user_buf,
-				    size_t count, loff_t *ppos)
+static int ldist_from_get(void *data, u64 *val)
 {
-	struct dentry *dent = file->f_path.dentry;
-	struct wult_info *wi = file->private_data;
-	char buf[32];
-	int err, len;
-	ssize_t res;
-	u64 val;
-
-	err = debugfs_file_get(dent);
-	if (err)
-		return err;
+	struct wult_info *wi = data;
 
 	mutex_lock(&wi->enable_mutex);
-	if (!strcmp(dent->d_name.name, LDIST_FROM_FNAME)) {
-		val = wi->ldist_from;
-	} else if (!strcmp(dent->d_name.name, LDIST_TO_FNAME)) {
-		val = wi->ldist_to;
-	} else {
-		err = -EINVAL;
-	}
+	*val = wi->ldist_from;
 	mutex_unlock(&wi->enable_mutex);
 
-	if (err) {
-		res = -EINVAL;
-		goto out;
-	}
-
-	len = snprintf(buf, ARRAY_SIZE(buf), "%llu\n", val);
-	res = simple_read_from_buffer(user_buf, count, ppos, buf, len);
-out:
-	debugfs_file_put(dent);
-	return res;
+	return 0;
 }
 
-static ssize_t dfs_write_rw_u64_file(struct file *file,
-				     const char __user *user_buf,
-				     size_t count, loff_t *ppos)
+static int ldist_from_set(void *data, u64 val)
 {
-	struct dentry *dent = file->f_path.dentry;
-	struct wult_info *wi = file->private_data;
+	struct wult_info *wi = data;
 	int err;
-	ssize_t len;
-	char buf[32];
-	u64 val;
-
-	err = debugfs_file_get(dent);
-	if (err)
-		return err;
-
-	len = simple_write_to_buffer(buf, ARRAY_SIZE(buf), ppos, user_buf,
-				     count);
-	if (len < 0)
-		goto out;
-
-	buf[len] = '\0';
-	err = kstrtoull(buf, 0, &val);
-	if (err) {
-		len = err;
-		goto out;
-	}
 
 	mutex_lock(&wi->enable_mutex);
 	if (wi->enabled) {
@@ -212,37 +165,53 @@ static ssize_t dfs_write_rw_u64_file(struct file *file,
 	err = -EINVAL;
 	if (val > wi->wdi->ldist_max || val < wi->wdi->ldist_min)
 		goto out_unlock;
-
-	if (!strcmp(dent->d_name.name, LDIST_FROM_FNAME)) {
-		if (val > wi->ldist_to)
-			goto out_unlock;
-		wi->ldist_from = val;
-	} else if (!strcmp(dent->d_name.name, LDIST_TO_FNAME)) {
-		if (val < wi->ldist_from)
-			goto out_unlock;
-		wi->ldist_to = val;
-	} else {
+	if (val > wi->ldist_to)
 		goto out_unlock;
-	}
-	mutex_unlock(&wi->enable_mutex);
 
-out:
-	debugfs_file_put(dent);
-	return len;
-
+	err = 0;
+	wi->ldist_from = val;
 out_unlock:
 	mutex_unlock(&wi->enable_mutex);
-	debugfs_file_put(dent);
 	return err;
 }
 
-/* Wult debugfs operations for R/W files backed by u64 variables. */
-static const struct file_operations dfs_ops_rw_u64 = {
-	.read = dfs_read_rw_u64_file,
-	.write = dfs_write_rw_u64_file,
-	.open = simple_open,
-	.llseek = default_llseek,
-};
+DEFINE_DEBUGFS_ATTRIBUTE(ldist_from_ops, ldist_from_get, ldist_from_set, "%llu\n");
+
+static int ldist_to_get(void *data, u64 *val)
+{
+	struct wult_info *wi = data;
+
+	mutex_lock(&wi->enable_mutex);
+	*val = wi->ldist_tom;
+	mutex_unlock(&wi->enable_mutex);
+	return 0;
+}
+
+static int ldist_to_set(void *data, u64 val)
+{
+	struct wult_info *wi = data;
+	int err;
+
+	mutex_lock(&wi->enable_mutex);
+	if (wi->enabled) {
+		/* Forbid changes if measurements are enabled. */
+		err = -EBUSY;
+		goto out_unlock;
+	}
+
+	err = -EINVAL;
+	if (val > wi->wdi->ldist_max || val < wi->wdi->ldist_min)
+		goto out_unlock;
+	if (val < wi->ldist_from)
+		goto out_unlock;
+
+	err = 0;
+	wi->ldist_from = val;
+out_unlock:
+	mutex_unlock(&wi->enable_mutex);
+	return err;
+}
+DEFINE_DEBUGFS_ATTRIBUTE(ldist_to_ops, ldist_to_get, ldist_to_set, "%llu\n");
 
 int wult_uapi_device_register(struct wult_info *wi)
 {
@@ -258,10 +227,8 @@ int wult_uapi_device_register(struct wult_info *wi)
 	debugfs_create_u64(LDIST_MIN_FNAME, 0444, wi->dfsroot, &wi->wdi->ldist_min);
 	debugfs_create_u64(LDIST_MAX_FNAME, 0444, wi->dfsroot, &wi->wdi->ldist_max);
 
-	debugfs_create_file(LDIST_FROM_FNAME, 0644, wi->dfsroot, wi,
-			    &dfs_ops_rw_u64);
-	debugfs_create_file(LDIST_TO_FNAME, 0644, wi->dfsroot, wi,
-			    &dfs_ops_rw_u64);
+	debugfs_create_file(LDIST_FROM_FNAME, 0644, wi->dfsroot, wi, &ldist_from_ops);
+	debugfs_create_file(LDIST_TO_FNAME, 0644, wi->dfsroot, wi, &ldist_to_ops);
 
 	return 0;
 }

--- a/drivers/idle/wult/uapi.c
+++ b/drivers/idle/wult/uapi.c
@@ -139,43 +139,6 @@ static const struct file_operations dfs_ops_bool = {
 	.llseek = default_llseek,
 };
 
-static ssize_t dfs_read_ro_u64_file(struct file *file, char __user *user_buf,
-				    size_t count, loff_t *ppos)
-{
-	struct dentry *dent = file->f_path.dentry;
-	struct wult_info *wi = file->private_data;
-	char buf[32];
-	int err, len;
-	ssize_t res;
-	u64 val;
-
-	err = debugfs_file_get(dent);
-	if (err)
-		return err;
-
-	if (!strcmp(dent->d_name.name, LDIST_MIN_FNAME)) {
-		val = wi->wdi->ldist_min;
-	} else if (!strcmp(dent->d_name.name, LDIST_MAX_FNAME)) {
-		val = wi->wdi->ldist_max;
-	} else {
-		res = -EINVAL;
-		goto out;
-	}
-
-	len = snprintf(buf, ARRAY_SIZE(buf), "%llu\n", val);
-	res = simple_read_from_buffer(user_buf, count, ppos, buf, len);
-out:
-	debugfs_file_put(dent);
-	return res;
-}
-
-/* Wult debugfs operations for R/O files backed by u64 variables. */
-static const struct file_operations dfs_ops_ro_u64 = {
-	.read = dfs_read_ro_u64_file,
-	.open = simple_open,
-	.llseek = default_llseek,
-};
-
 static ssize_t dfs_read_rw_u64_file(struct file *file, char __user *user_buf,
 				    size_t count, loff_t *ppos)
 {
@@ -291,10 +254,10 @@ int wult_uapi_device_register(struct wult_info *wi)
 			    &dfs_ops_bool);
 	debugfs_create_file(EARLY_INTR_FNAME, 0644, wi->dfsroot, wi,
 			    &dfs_ops_bool);
-	debugfs_create_file(LDIST_MIN_FNAME, 0444, wi->dfsroot, wi,
-			    &dfs_ops_ro_u64);
-	debugfs_create_file(LDIST_MAX_FNAME, 0444, wi->dfsroot, wi,
-			    &dfs_ops_ro_u64);
+
+	debugfs_create_u64(LDIST_MIN_FNAME, 0444, wi->dfsroot, &wi->wdi->ldist_min);
+	debugfs_create_u64(LDIST_MAX_FNAME, 0444, wi->dfsroot, &wi->wdi->ldist_max);
+
 	debugfs_create_file(LDIST_FROM_FNAME, 0644, wi->dfsroot, wi,
 			    &dfs_ops_rw_u64);
 	debugfs_create_file(LDIST_TO_FNAME, 0644, wi->dfsroot, wi,

--- a/drivers/idle/wult/wult.h
+++ b/drivers/idle/wult/wult.h
@@ -122,6 +122,8 @@ struct wult_info {
 	bool enabled;
 	/* Whether the early interrupts feature is enabled. */
 	bool early_intr;
+	/* Internal parser cache for the above */
+	bool ei;
 	/*
 	 * Launch distance range in nanoseconds. We pick a random number from
 	 * this range when selecting time for the delayed event.

--- a/drivers/idle/wult/wult_hrt.c
+++ b/drivers/idle/wult/wult_hrt.c
@@ -12,6 +12,8 @@
 #include <linux/ktime.h>
 #include <linux/module.h>
 #include <linux/time.h>
+#include <asm/cpu_device_id.h>
+#include <asm/intel-family.h>
 #include <asm/msr.h>
 #include "wult.h"
 
@@ -100,12 +102,19 @@ static struct wult_device_ops wult_hrt_ops = {
 	.exit = exit_device,
 };
 
+static const struct x86_cpu_id intel_cpu_ids[] = {
+	X86_MATCH_VENDOR_FAM(INTEL, 6, NULL),
+	{}
+};
+MODULE_DEVICE_TABLE(x86cpu, intel_cpu_ids);
+
 static int __init wult_hrt_init(void)
 {
-	if (boot_cpu_data.x86_vendor == X86_VENDOR_INTEL &&
-	    boot_cpu_data.x86 < 6) {
-		wult_err("unsupported Intel CPU family %d, required family 6 "
-		         "or higher", boot_cpu_data.x86);
+	const struct x86_cpu_id *id;
+
+	id = x86_match_cpu(intel_cpu_ids);
+	if (!id) {
+		wult_err("unsupported Intel CPU family, required family 6 or higher");
 		return -EINVAL;
 	}
 

--- a/drivers/idle/wult/wult_igb.c
+++ b/drivers/idle/wult/wult_igb.c
@@ -25,7 +25,7 @@
 static struct wult_trace_data_info tdata[] = {
 	{ .name = "WarmupDelay" },
 	{ .name = "LatchDelay" },
-	{ NULL },
+	{ }
 };
 
 /* Read a 32-bit NIC register. */

--- a/drivers/idle/wult/wult_tdt.c
+++ b/drivers/idle/wult/wult_tdt.c
@@ -33,7 +33,7 @@
 static struct wult_trace_data_info tdata[] = {
 	{ .name = "BICyc" },
 	{ .name = "BIMonotonic" },
-	{ NULL },
+	{ }
 };
 struct wult_tdt {
 	struct hrtimer timer;


### PR DESCRIPTION
This is bunch of untested patches against wult drivers. Used APIs have not been checked for minimal kernel version, but I believe the v5.15 covers 99%+ of them. The most controversial change is the CPU feature test, since it changes behaviour on testing boot CPU instead of given one. That patch can be avoided in the current form without conflicts to the rest.

That said, consider this as a review comments implemented in code and apply changes with caution.