### PR TITLE
deps: pin pepc and stats-collect to their GitHub release URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ dependencies = [
     "pyyaml",
     "numpy",
     "pandas>=2.1.0",
-    "pepc>=2.0.1",
-    "stats-collect>=1.0.68",
+    "pepc @ git+https://github.com/intel/pepc.git@release",
+    "stats-collect @ git+https://github.com/intel/stats-collect.git@release",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
The pyproject currently declares `pepc` and `stats-collect` as version-floor PyPI requirements (`pepc>=2.0.1`, `stats-collect>=1.0.68`). Per the install guide at `docs/guide-install.md`, both are distributed via GitHub (`intel/pepc`, `intel/stats-collect`) and must be installed into the same venv before `wult` for the deps to resolve cleanly. That ordering is easy to miss when somebody copy-pastes the standalone `pip3 install git+...wult.git@release` example from the install guide into a fresh venv, or runs it from a script that didn't pre-install both upstream tools.

Switching the deps to PEP 440 direct URL references makes the install order-independent: `pip install git+...wult.git@release` pulls `pepc` and `stats-collect` from the upstream repositories regardless of whether they were pre-installed. The `@release` tag is the same one the install guide already uses for each, so the version pin behaviour is unchanged.

If either name ever gets published to PyPI, these lines can be flipped back to regular version ranges without further effort.